### PR TITLE
fix: adds packageImportPath for android build

### DIFF
--- a/react-native.config.js
+++ b/react-native.config.js
@@ -6,6 +6,7 @@ module.exports = {
     platforms: {
       android: {
         cmakeListsPath: 'generated/jni/CMakeLists.txt',
+        packageImportPath: 'import com.shakebugs.react.ShakePackage;',
       },
     },
   },


### PR DESCRIPTION
Implementation of @Osilos fix for 52 expo sdk

https://github.com/shakebugs/shake-react-native/issues/12