### PR TITLE
fix: backgroundColorValue for android

### DIFF
--- a/android/src/main/java/com/shakebugs/react/utils/Mapper.kt
+++ b/android/src/main/java/com/shakebugs/react/utils/Mapper.kt
@@ -321,7 +321,7 @@ class Mapper(private val context: Context) {
         val shakeTheme = ShakeTheme()
         shakeTheme.fontFamilyBoldValue = findAssetPath(context, fontFamilyBold)
         shakeTheme.fontFamilyMediumValue = findAssetPath(context, fontFamilyMedium)
-        shakeTheme.secondaryBackgroundColorValue = stringToColor(backgroundColor)
+        shakeTheme.backgroundColorValue = stringToColor(backgroundColor)
         shakeTheme.secondaryBackgroundColorValue = stringToColor(secondaryBackgroundColor)
         shakeTheme.textColorValue = stringToColor(textColor)
         shakeTheme.secondaryTextColorValue = stringToColor(secondaryTextColor)


### PR DESCRIPTION
Fix typo in backgroundColorValue for Android

It resolves the issue reported here: https://github.com/shakebugs/shake-react-native/issues/15